### PR TITLE
Update deprecated icon names, to fix missing buttons

### DIFF
--- a/SomaFm-Radio@alireza6677.gmail.com/extension.js
+++ b/SomaFm-Radio@alireza6677.gmail.com/extension.js
@@ -186,13 +186,13 @@ const Popup = new Lang.Class({
 
     },
     stopped: function () {
-        this.controlbtns.icon.set_icon_name('gtk-media-play');
+        this.controlbtns.icon.set_icon_name('media-playback-start');
         this.controlbtns.playing = false;
         this.setLoading(false);
         this.desc.set_text('Soma FM');
     },
     channelChanged: function () {
-        this.controlbtns.icon.set_icon_name('gtk-media-stop');
+        this.controlbtns.icon.set_icon_name('media-playback-stop');
         this.controlbtns.playing = true;
         this.setLoading(false);
         this.setLoading(true);

--- a/SomaFm-Radio@alireza6677.gmail.com/radio.js
+++ b/SomaFm-Radio@alireza6677.gmail.com/radio.js
@@ -22,20 +22,20 @@ const ControlButtons = new Lang.Class({
 
         this.prev = new St.Icon({
             style_class: 'icon',
-            icon_name: 'gtk-media-previous',
+            icon_name: 'media-skip-backward',
             reactive: true,
             icon_size: 25,
         });
 
         this.icon = new St.Icon({
             style_class: 'icon',
-            icon_name: 'gtk-media-play',
+            icon_name: 'media-playback-start',
             reactive: true,
         });
 
         this.next = new St.Icon({
             style_class: 'icon',
-            icon_name: 'gtk-media-next',
+            icon_name: 'media-skip-forward',
             reactive: true,
             icon_size: 25,
         });
@@ -65,12 +65,12 @@ const ControlButtons = new Lang.Class({
         this.icon.connect('button-press-event', Lang.bind(this, function () {
             if (this.playing) {
                 this.player.stop();
-                this.icon.set_icon_name('gtk-media-play');
+                this.icon.set_icon_name('media-playback-start');
                 this.pr.setLoading(false);
                 this.pr.desc.set_text('Soma FM');
             } else {
                 this.player.play();
-                this.icon.set_icon_name('gtk-media-stop');
+                this.icon.set_icon_name('media-playback-stop');
                 this.pr.setLoading(false);
                 this.pr.setLoading(true);
                 if (this.pr.err)


### PR DESCRIPTION
The stop button icon was missing on Fedora with the default Gnome theme. Turned out that the `gtk-` icon names [have been deprecated](https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html). After updating the names, the button appeared.

Thanks, by the way; this is a very good extension.
